### PR TITLE
fix yaw loading - convert to radians from degrees

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -6,7 +6,10 @@ from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 from geometry_msgs.msg import TwistStamped
 import math
 
-from twist_controller import Controller
+from twist_controller import Controller, VehicleInfo
+from styx_msgs.msg import Lane
+from multiprocessing import Lock
+
 
 '''
 You can build this node only after you have built (or partially built) the `waypoint_updater` node.
@@ -46,6 +49,10 @@ class DBWNode(object):
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
 
+        vehicle_info = VehicleInfo(vehicle_mass, fuel_capacity, brake_deadband, decel_limit,
+                                   accel_limit, wheel_radius, wheel_base, steer_ratio,
+                                   max_lat_accel, max_steer_angle)
+
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
                                          SteeringCmd, queue_size=1)
         self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
@@ -53,25 +60,42 @@ class DBWNode(object):
         self.brake_pub = rospy.Publisher('/vehicle/brake_cmd',
                                          BrakeCmd, queue_size=1)
 
-        # TODO: Create `TwistController` object
-        # self.controller = TwistController(<Arguments you wish to provide>)
+        # Create `TwistController` object
+        self.controller = Controller(vehicle_info)
 
-        # TODO: Subscribe to all the topics you need to
+        self.dbw_enabled = True
+        self.current_velocity = None
+        self.twist_cmd = None
+        #
+        # lock is required because in rospy subscriber's callbacks are executed in separate threads
+        # https://answers.ros.org/question/110336/python-spin-once-equivalent/
+        self.lock = Lock()
+        #
+        # subscribe to the required topics
+        #
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb, queue_size=1)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb)
+        rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cmd_cb)
 
         self.loop()
 
     def loop(self):
         rate = rospy.Rate(50) # 50Hz
         while not rospy.is_shutdown():
-            # TODO: Get predicted throttle, brake, and steering using `twist_controller`
-            # You should only publish the control commands if dbw is enabled
-            # throttle, brake, steering = self.controller.control(<proposed linear velocity>,
-            #                                                     <proposed angular velocity>,
-            #                                                     <current linear velocity>,
-            #                                                     <dbw status>,
-            #                                                     <any other argument you need>)
-            # if <dbw is enabled>:
-            #   self.publish(throttle, brake, steer)
+            #
+            # Get predicted throttle, brake, and steering using `twist_controller`
+            # Only publish the control commands if dbw is enabled
+            #
+            with self.lock:
+                twist_cmd = self.twist_cmd
+                current_velocity = self.current_velocity
+                dbw_enabled = self.dbw_enabled
+
+            if not (twist_cmd is None or current_velocity is None):
+                throttle, brake, steering = self.controller.control(twist_cmd, current_velocity, dbw_enabled)
+                if dbw_enabled:
+                    self.publish(throttle, brake, steering)
+
             rate.sleep()
 
     def publish(self, throttle, brake, steer):
@@ -91,6 +115,18 @@ class DBWNode(object):
         bcmd.pedal_cmd_type = BrakeCmd.CMD_TORQUE
         bcmd.pedal_cmd = brake
         self.brake_pub.publish(bcmd)
+
+    def dbw_enabled_cb(self, dbw_enabled):
+        with self.lock:
+            self.dbw_enabled = dbw_enabled
+
+    def current_velocity_cb(self, velocity):
+        with self.lock:
+            self.current_velocity = velocity
+
+    def twist_cmd_cb(self, twist_cmd):
+        with self.lock:
+            self.twist_cmd = twist_cmd
 
 
 if __name__ == '__main__':

--- a/ros/src/twist_controller/launch/dbw_sim.launch
+++ b/ros/src/twist_controller/launch/dbw_sim.launch
@@ -8,7 +8,7 @@
         <param name="accel_limit" value="1." />
         <param name="wheel_radius" value="0.335" />
         <param name="wheel_base" value="3" />
-        <param name="steer_ratio" value="2.67" />
+        <param name="steer_ratio" value="14.8" />
         <param name="max_lat_accel" value="3." />
         <param name="max_steer_angle" value="8." />
     </node>

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -20,10 +20,10 @@ class PID(object):
     def step(self, error, sample_time):
         self.last_int_val = self.int_val
 
-        integral = self.int_val + error * sample_time;
-        derivative = (error - self.last_error) / sample_time;
+        integral = self.int_val + error * sample_time
+        derivative = (error - self.last_error) / sample_time if sample_time > 1e-3 else 0
 
-        y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
+        y = self.kp * error + self.ki * self.int_val + self.kd * derivative
         val = max(self.min, min(y, self.max))
 
         if val > self.max:

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,14 +1,54 @@
+import math
+from collections import namedtuple
+import rospy
+from pid import PID
+from yaw_controller import YawController
+
+VehicleInfo = namedtuple('VehicleInfo',
+                         ['mass', 'fuel_capacity', 'brake_deadband', 'decel_limit',
+                          'accel_limit', 'wheel_radius', 'wheel_base', 'steer_ratio',
+                          'max_lat_accel', 'max_steer_angle'])
 
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
 
 
 class Controller(object):
-    def __init__(self, *args, **kwargs):
-        # TODO: Implement
-        pass
+    def __init__(self, vehicle_info):
+        self.pid_controller = PID(0.2, 0.002, 0.0, vehicle_info.decel_limit, vehicle_info.accel_limit)
+        self.yaw_controller = YawController(vehicle_info.wheel_base, vehicle_info.steer_ratio,
+                                            0, vehicle_info.max_lat_accel,
+                                            vehicle_info.max_steer_angle)
 
-    def control(self, *args, **kwargs):
-        # TODO: Change the arg, kwarg list to suit your needs
-        # Return throttle, brake, steer
-        return 1., 0., 0.
+        self.prev_time = None
+
+    def control(self, twist_cmd, current_velocity, dbw_enabled):
+
+        if not dbw_enabled:
+            self.pid_controller.reset()
+            return 0.0, 0.0, 0.0
+
+        target_linear_velocity = twist_cmd.twist.linear.x
+        target_angular_velocity = twist_cmd.twist.angular.z
+        current_linear_velocity = current_velocity.twist.linear.x
+        current_agular_velocity = current_velocity.twist.angular.z
+
+        #rospy.loginfo("tl = %f, cl = %f, ta = %f", target_linear_velocity, current_linear_velocity, target_angular_velocity)
+
+        linear_velocity_error = target_linear_velocity - current_linear_velocity
+        time = rospy.get_time()
+        delta_t = time - self.prev_time if self.prev_time is not None else 0
+        self.prev_time = time
+        linear_control = self.pid_controller.step(linear_velocity_error, delta_t)
+
+        throttle = 0.0
+        if linear_control > 0.0:
+            throttle = linear_control
+
+        brake = 0.0
+        if linear_control < 0.0:
+            brake = -linear_control
+
+        steer = self.yaw_controller.get_steering(target_linear_velocity, target_angular_velocity, current_linear_velocity)
+
+        return throttle, brake, steer

--- a/ros/src/twist_controller/yaw_controller.py
+++ b/ros/src/twist_controller/yaw_controller.py
@@ -1,3 +1,4 @@
+import rospy
 from math import atan
 
 class YawController(object):
@@ -19,7 +20,15 @@ class YawController(object):
         angular_velocity = current_velocity * angular_velocity / linear_velocity if abs(linear_velocity) > 0. else 0.
 
         if abs(current_velocity) > 0.1:
-            max_yaw_rate = abs(self.max_lat_accel / current_velocity);
+            max_yaw_rate = abs(self.max_lat_accel / current_velocity)
             angular_velocity = max(-max_yaw_rate, min(max_yaw_rate, angular_velocity))
 
-        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0;
+        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0
+        """
+        if angular_velocity == 0:
+            return 0
+        radius = current_velocity / angular_velocity
+        steer = self.get_angle(radius) if radius != 0 else 0
+        #steer = math.degrees(steer)
+        rospy.loginfo("steer = %f", steer)
+        """

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -30,7 +30,7 @@ class WaypointLoader(object):
         if os.path.isfile(path):
             waypoints = self.load_waypoints(path)
             self.publish(waypoints)
-            rospy.loginfo('Waypoint Loded')
+            rospy.loginfo('Waypoint Loaded')
         else:
             rospy.logerr('%s is not a file', path)
 
@@ -49,7 +49,7 @@ class WaypointLoader(object):
                 p.pose.pose.position.x = float(wp['x'])
                 p.pose.pose.position.y = float(wp['y'])
                 p.pose.pose.position.z = float(wp['z'])
-                q = self.quaternion_from_yaw(float(wp['yaw']))
+                q = self.quaternion_from_yaw(math.radians(float(wp['yaw'])))
                 p.pose.pose.orientation = Quaternion(*q)
                 p.twist.twist.linear.x = float(self.velocity*0.27778)
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -3,8 +3,9 @@
 import rospy
 from geometry_msgs.msg import PoseStamped
 from styx_msgs.msg import Lane, Waypoint
-
 import math
+import tf
+from multiprocessing import Lock
 
 '''
 This node will publish waypoints from the car's current position to some `x` distance ahead.
@@ -23,13 +24,12 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
 
-
 class WaypointUpdater(object):
     def __init__(self):
         rospy.init_node('waypoint_updater')
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        self.base_waypoints_sub = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb, queue_size=1)
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
 
@@ -37,23 +37,80 @@ class WaypointUpdater(object):
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
         # TODO: Add other member variables you need below
+        self.waypoints_msg = None
+        self.prev_closest_idx = 0
+        #
+        # lock is required because in rospy subscriber's callbacks are executed in separate threads
+        # https://answers.ros.org/question/110336/python-spin-once-equivalent/
+        self.lock = Lock()
 
         rospy.spin()
 
     def pose_cb(self, msg):
-        # TODO: Implement
-        pass
+        with self.lock:
+            waypoints_msg = self.waypoints_msg
 
-    def waypoints_cb(self, waypoints):
-        # TODO: Implement
-        pass
+        waypoints = waypoints_msg.waypoints
+        if waypoints is not None:
+            #
+            # find a closest waypoint
+            #
+            closest_idx = self.prev_closest_idx
+            if closest_idx > 5:
+                closest_idx -= 5
+            closest_distance = 1e6
+            distance = lambda a, b: math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2)  # + (a.z - b.z) ** 2)
+            for idx in range(closest_idx, len(waypoints)):
+                point = waypoints[idx]
+                dist = distance(point.pose.pose.position, msg.pose.position)
+                if dist < closest_distance:
+                    closest_distance = dist
+                    closest_idx = idx
+                else:
+                    break
+            self.prev_closest_idx = closest_idx
+            point = waypoints[closest_idx]
+
+            #
+            # adjust it by heading
+            #
+            q = point.pose.pose.orientation
+            position = point.pose.pose.position
+            _, _, yaw = tf.transformations.euler_from_quaternion((q.x, q.y, q.z, q.w))
+            heading = math.atan2((position.y - msg.pose.position.y), (position.x - msg.pose.position.x))
+
+            if abs(yaw - heading) > (math.pi / 4):
+                closest_idx += 1
+
+            #
+            # compose final waypoints
+            #
+            final_waypoints = Lane()
+            final_waypoints.header.frame_id = self.waypoints_msg.header.frame_id
+            final_waypoints.header.stamp = rospy.Time.now()
+            final_waypoints.waypoints = waypoints[closest_idx:min(len(waypoints), closest_idx+LOOKAHEAD_WPS)]
+
+            #
+            # publish it
+            #
+            self.final_waypoints_pub.publish(final_waypoints)
+
+    def waypoints_cb(self, msg):
+        with self.lock:
+            if self.waypoints_msg is None or self.waypoints_msg.header.stamp != msg.header.stamp:
+                self.waypoints_msg = msg
+                self.prev_closest_idx = 0
+
+        self.base_waypoints_sub.unregister()
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement
+        rospy.loginfo('traffic_cb called')
         pass
 
     def obstacle_cb(self, msg):
         # TODO: Callback for /obstacle_waypoint message. We will implement it later
+        rospy.loginfo('obstacle_cb called')
         pass
 
     def get_waypoint_velocity(self, waypoint):
@@ -69,7 +126,6 @@ class WaypointUpdater(object):
             dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
             wp1 = i
         return dist
-
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Simulator (wp_yaw_const.txt) and site (chrchlot_with_cars.csv) waypoint files in data folder have yaw field. According to the content that field is waypoint heading in degrees. This value could be used but it is screwed in waypoint_loader.py by casting it to quaternion as radiant value:
q = self.quaternion_from_yaw(float(wp['yaw']))
