### PR TITLE
Use an absolute path for profile.tmp in unity_simulator_launcher.sh

### DIFF
--- a/ros/src/styx/unity_simulator_launcher.sh
+++ b/ros/src/styx/unity_simulator_launcher.sh
@@ -2,7 +2,8 @@
 #
 # Script to launch the CarND Unity simulator
 
-USER_PROFILE="profile.tmp"
+THIS_DIR="$(cd "$(dirname "$0")" && pwd -P && cd - > /dev/null)"
+USER_PROFILE="$THIS_DIR/profile.tmp"
 
 if [ ! -f "$USER_PROFILE" ];
   then


### PR DESCRIPTION
Otherwise the script fails to run when being called from
another directory than the one it's contained in.

THIS_DIR = the absolute path to the directory where
`unity_simulator_launcher.sh` is located.