### PR TITLE
Set correct encoding before publishing /image_color

### DIFF
--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -179,7 +179,7 @@ class Bridge(object):
         image = PIL_Image.open(BytesIO(base64.b64decode(imgString)))
         image_array = np.asarray(image)
 
-        image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="passthrough")
+        image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="rgb8")
         self.publishers['image'].publish(image_message)
 
     def callback_steering(self, data):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -154,7 +154,6 @@ class TLDetector(object):
             self.prev_light_loc = None
             return False
 
-        self.camera_image.encoding = "rgb8"
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
         x, y = self.project_to_image_plane(light.pose.pose.position)


### PR DESCRIPTION
This way, one can visualize the image by running:

    rosrun image_view image_view image:=/image_color

It's also then unnecessary to set that encoding in
`tl_detector.py`.