### PR TITLE
Fixed frame ids inconsistency

### DIFF
--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -63,7 +63,7 @@ class Bridge(object):
 
         light.header = Header()
         light.header.stamp = rospy.Time.now()
-        light.header.frame_id = 'world'
+        light.header.frame_id = '/world'
 
         light.pose = self.create_pose(x, y, z, yaw)
         light.state = state
@@ -75,7 +75,7 @@ class Bridge(object):
 
         pose.header = Header()
         pose.header.stamp = rospy.Time.now()
-        pose.header.frame_id = 'world'
+        pose.header.frame_id = '/world'
 
         pose.pose.position.x = x
         pose.pose.position.y = y
@@ -115,7 +115,7 @@ class Bridge(object):
     def create_point_cloud_message(self, pts):
         header = Header()
         header.stamp = rospy.Time.now()
-        header.frame_id = 'world'
+        header.frame_id = '/world'
         cloud_message = pcl2.create_cloud_xyz32(header, pts)
         return cloud_message
 
@@ -152,7 +152,7 @@ class Bridge(object):
             self.publishers['obstacle'].publish(pose)
         header = Header()
         header.stamp = rospy.Time.now()
-        header.frame_id = 'world'
+        header.frame_id = '/world'
         cloud = pcl2.create_cloud_xyz32(header, data['obstacles'])
         self.publishers['obstacle_points'].publish(cloud)
 
@@ -167,7 +167,7 @@ class Bridge(object):
         lights = TrafficLightArray()
         header = Header()
         header.stamp = rospy.Time.now()
-        header.frame_id = 'world'
+        header.frame_id = '/world'
         lights.lights = [self.create_light(*e) for e in zip(x, y, z, yaw, status)]
         self.publishers['trafficlights'].publish(lights)
 

--- a/ros/src/tl_detector/light_publisher.py
+++ b/ros/src/tl_detector/light_publisher.py
@@ -35,7 +35,7 @@ class TLPublisher(object):
 
         light.header = Header()
         light.header.stamp = rospy.Time.now()
-        light.header.frame_id = 'world'
+        light.header.frame_id = '/world'
 
         light.pose = self.create_pose(x, y, z, yaw)
         light.state = state
@@ -47,7 +47,7 @@ class TLPublisher(object):
 
         pose.header = Header()
         pose.header.stamp = rospy.Time.now()
-        pose.header.frame_id = 'world'
+        pose.header.frame_id = '/world'
 
         pose.pose.position.x = x
         pose.pose.position.y = y


### PR DESCRIPTION
Sometimes it's 'world' some other it's '/world'. It seems to be a convention to prefix it with '/' so I made sure we only use '/world'.