### PR TITLE
fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy>=1.13.1
 Pillow>=2.2.1
 scipy
 keras
-tensorflow=1.0.0
+tensorflow>=1.0.0
 h5py


### PR DESCRIPTION
If a version is specified, then the operator should be '==' or '>='.