### PR TITLE
Add image-proc package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip install -r requirements.txt
 # install required ros dependencies
 RUN apt-get install -y ros-$ROS_DISTRO-cv-bridge
 RUN apt-get install -y ros-$ROS_DISTRO-pcl-ros
+RUN apt-get install -y ros-$ROS_DISTRO-image-proc
 
 # socket io
 RUN apt-get install -y netbase
@@ -30,3 +31,4 @@ RUN apt-get install -y netbase
 RUN mkdir /capstone
 VOLUME ["/capstone"]
 VOLUME ["/root/.ros/log/"]
+WORKDIR /capstone/ros

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy>=1.13.1
 Pillow>=2.2.1
 scipy
 keras
-tensorflow=1.0.0
+tensorflow==1.0.0
 h5py


### PR DESCRIPTION
the image-proc package is required while running site.launch
also fixed the `requirement.txt` and set default WORKDIR to `/capstone/ros`