### PR TITLE
Upgrade Pillow library to 4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict==2.0.0
 eventlet==0.19.0
 python-socketio==1.6.1
 numpy==1.13.1
-Pillow==2.2.1
+Pillow==4.3.0
 scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0


### PR DESCRIPTION
Otherwise `bridge.py` fails to unpack the image data.
See discussion:

https://carnd.slack.com/archives/C6NVDVAQ3/p1507463503000006