### PR TITLE
Waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -42,14 +42,41 @@ class WaypointUpdater(object):
 
     def pose_cb(self, msg):
         self.ego_pos = msg.pose
-        
+
         if self.wps is not None:	#Don't proceed until we have received waypoints
             
+            # Get car orientation
+            car_x, car_y = self.ego_pos.position.x, self.ego_pos.position.y
+            quaternion = (self.ego_pos.orientation.x, self.ego_pos.orientation.y,
+                        self.ego_pos.orientation.z, self.ego_pos.orientation.w)
+            euler = tf.transformations.euler_from_quaternion(quaternion)
+            car_yaw = euler[2]
+            
             #return the index of the closest waypoint ahead of us
-            closest_idx_waypoint = self.closest_waypoint_ahead()
+            closest_idx_waypoint = self.closest_waypoint_ahead(car_x, car_y, car_yaw, self.wps.waypoints)
 
             #final waypoints is a subset of original set of waypoints
-            self.final_wps.waypoints = self.wps.waypoints[closest_wp:closest_wp+LOOKAHEAD_WPS]
+            self.final_wps.waypoints = self.wps.waypoints[closest_idx_waypoint:closest_idx_waypoint+LOOKAHEAD_WPS]
+
+            #check we didn't reach the end of the list and otherwise loopback to start of the list
+            if len(self.final_wps.waypoints) < LOOKAHEAD_WPS:
+                extra_points_needed = LOOKAHEAD_WPS - len(self.final_wps.waypoints)
+
+                # we need to get points from the start of the list ensuring next point is closest ahead
+                last_x = self.wps.waypoints[-1].pose.pose.position.x
+                last_y = self.wps.waypoints[-1].pose.pose.position.y
+                last_x2 = self.wps.waypoints[-2].pose.pose.position.x
+                last_y2 = self.wps.waypoints[-2].pose.pose.position.y
+                last_yaw = math.atan2(last_y - last_y2, last_x - last_x2)
+                # we don't include last points of the list to ensure we go back to the beginning of the list
+                first_extra_point = self.closest_waypoint_ahead(last_x, last_y, last_yaw, self.wps.waypoints[0:-10])
+
+                #we complete our list to desired number of points
+                self.final_wps.waypoints.extend(self.wps.waypoints[first_extra_point:first_extra_point+extra_points_needed])
+
+            if len(self.final_wps.waypoints) != LOOKAHEAD_WPS:
+                rospy.logwarn("List of /final_waypoints does not contain target number of elements")
+
             self.final_waypoints_pub.publish(self.final_wps)
 
     def waypoints_cb(self, waypoints):
@@ -82,24 +109,19 @@ class WaypointUpdater(object):
             wp1 = i
         return dist
 
-    def closest_waypoint_ahead(self):
+    def closest_waypoint_ahead(self, pos_x, pos_y, yaw, waypoints):
         ''' Return index of closest point ahead '''
 
-        # Get car orientation
-        car_x, car_y = self.ego_pos.position.x, self.ego_pos.position.y
-        quaternion = (self.ego_pos.orientation.x, self.ego_pos.orientation.y,
-                      self.ego_pos.orientation.z, self.ego_pos.orientation.w)
-        euler = tf.transformations.euler_from_quaternion(quaternion)
-        car_yaw = euler[2]
-        loginfo = 'Car yaw: {} | x: {} | y: {}'.format(car_yaw, car_x, car_y)
+        # Create some logging info
+        loginfo = 'yaw: {} | x: {} | y: {}'.format(yaw, pos_x, pos_y)
 
         # Define unit vector for car orientation in global (x, y) coordinates
-        orient_x, orient_y = math.cos(car_yaw), math.sin(car_yaw)
+        orient_x, orient_y = math.cos(yaw), math.sin(yaw)
 
         # Filter waypoints to keep only the ones ahead of us by checking scalar product
-        waypoints_ahead = [(n, wp) for (n, wp) in enumerate(self.wps.waypoints)
-                           if (orient_x * (wp.pose.pose.position.x - car_x) +
-                           orient_y * (wp.pose.pose.position.y - car_y)) > 0]
+        waypoints_ahead = [(n, wp) for (n, wp) in enumerate(waypoints)
+                           if (orient_x * (wp.pose.pose.position.x - pos_x) +
+                           orient_y * (wp.pose.pose.position.y - pos_y)) > 0]
         if not len(waypoints_ahead):
             rospy.logwarn("No points detected ahead of us")
         

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -5,7 +5,6 @@ from geometry_msgs.msg import PoseStamped
 from styx_msgs.msg import Lane, Waypoint
 
 import math
-#import sys
 
 '''
 This node will publish waypoints from the car's current position to some `x` distance ahead.
@@ -32,11 +31,12 @@ class WaypointUpdater(object):
 	self.wps = 'None'
 	self.final_wps = 'None'
 	self.first_pass = True	
-        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)	       
+    rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)	       
 	rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
-        rospy.spin()
+
+    # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
+    self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+    rospy.spin()
 
     def pose_cb(self, msg):        
 	self.ego_pos = msg.pose.position

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -53,8 +53,8 @@ class WaypointUpdater(object):
 
             #Log closest waypoint position
             log_info = 'Current position: ({}; {}) | Closest waypoint idx #{}: ({}; {})'.format(
-                self.wps.waypoints[closest_wp].pose.pose.position.x, self.wps.waypoints[closest_wp].pose.pose.position.y,
-                closest_wp, self.ego_pos.x, self.ego_pos.y)
+                self.ego_pos.x, self.ego_pos.y, closest_wp,
+                self.wps.waypoints[closest_wp].pose.pose.position.x, self.wps.waypoints[closest_wp].pose.pose.position.y)
             rospy.loginfo_throttle(1, log_info) # ensure we don't log more than once per second
 
             #final waypoints is a subset of original set of waypoints

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -41,14 +41,12 @@ class WaypointUpdater(object):
     def pose_cb(self, msg):
         self.ego_pos = msg.pose.position
         if self.wps != 'None':	#Don't proceed until we have received waypoints
-            #return the index of the closest waypoint, given our current position (pose)
-            distances = []	
-            find_dist = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)	
-            for i in range(len(self.wps.waypoints)):
-                #find the distance between each waypoint and the current position
-                distances.append(find_dist(self.wps.waypoints[i].pose.pose.position, self.ego_pos))
         
-            #find index of waypoint closet to current position
+            #return the index of the closest waypoint, given our current position (pose)
+            find_dist = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
+            distances = [find_dist(waypoint.pose.pose.position, self.ego_pos) for waypoint in self.wps.waypoints]
+        
+            #find index of waypoint closest to current position
             closest_wp = distances.index(min(distances))
 
             #Log closest waypoint position


### PR DESCRIPTION
I updated waypoint_updater with following functions:
- ensure that the closest waypoint we select is always ahead of us
- if we don't have enough elements (we are at the end of the list), we go back to the beginning of the list and continue from closest waypoint ahead of us
- copy /base_waypoints only once to ensure we have the complete list (list is shortened later)
- added debugging info (you can use rqt_console to explore it easily)

I tested it and monitored waypoints returned in the simulator and everything seemed to work, including when reaching the end of the list. Also commands are still published to /twist_cmd.