### PR TITLE
Updates and error fixes to pid.py.

### DIFF
--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -11,20 +11,17 @@ class PID(object):
         self.min = mn
         self.max = mx
 
-        self.int_val = self.last_int_val = self.last_error = 0.
+        self.int_val = self.last_error = 0.
 
     def reset(self):
         self.int_val = 0.0
-        self.last_int_val = 0.0
 
     def step(self, error, sample_time):
-        self.last_int_val = self.int_val
 
         integral = self.int_val + error * sample_time;
         derivative = (error - self.last_error) / sample_time;
 
-        y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
-        val = max(self.min, min(y, self.max))
+        val = self.kp * error + self.ki * self.int_val + self.kd * derivative;
 
         if val > self.max:
             val = self.max


### PR DESCRIPTION
Fixed small bug in PID code that caused the integral term to continue to accumulate error, even when output had reached max or min. Also removed unused `self.last_int_val`.