### PR TITLE
synchronize subscribers in tl_detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 
 build
 devel
+logs
+.catkin_tools
 
 profile.tmp

--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -61,7 +61,6 @@ class Bridge(object):
     def create_light(self, x, y, z, yaw, state):
         light = TrafficLight()
 
-        light.header = Header()
         light.header.stamp = rospy.Time.now()
         light.header.frame_id = '/world'
 
@@ -73,7 +72,6 @@ class Bridge(object):
     def create_pose(self, x, y, z, yaw=0.):
         pose = PoseStamped()
 
-        pose.header = Header()
         pose.header.stamp = rospy.Time.now()
         pose.header.frame_id = '/world'
 
@@ -165,9 +163,8 @@ class Bridge(object):
         status = data['light_state']
 
         lights = TrafficLightArray()
-        header = Header()
-        header.stamp = rospy.Time.now()
-        header.frame_id = '/world'
+        lights.header.stamp = rospy.Time.now()
+        lights.header.frame_id = '/world'
         lights.lights = [self.create_light(*e) for e in zip(x, y, z, yaw, status)]
         self.publishers['trafficlights'].publish(lights)
 
@@ -175,11 +172,13 @@ class Bridge(object):
         self.publishers['dbw_status'].publish(Bool(data))
 
     def publish_camera(self, data):
+        now = rospy.Time.now()
         imgString = data["image"]
         image = PIL_Image.open(BytesIO(base64.b64decode(imgString)))
         image_array = np.asarray(image)
 
         image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="rgb8")
+        image_message.header.stamp = now
         self.publishers['image'].publish(image_message)
 
     def callback_steering(self, data):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -7,7 +7,7 @@ from styx_msgs.msg import Lane
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 from light_classification.tl_classifier import TLClassifier
-import tf
+from message_filters import ApproximateTimeSynchronizer, Subscriber
 import cv2
 import yaml
 
@@ -22,8 +22,20 @@ class TLDetector(object):
         self.camera_image = None
         self.lights = []
 
-        sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        config_string = rospy.get_param("/traffic_light_config")
+        self.config = yaml.load(config_string)
+
+        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
+
+        self.bridge = CvBridge()
+        self.light_classifier = TLClassifier()
+
+        self.state = TrafficLight.UNKNOWN
+        self.last_state = TrafficLight.UNKNOWN
+        self.last_wp = -1
+        self.state_count = 0
+
+        self.waypoints_sub = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
         '''
         /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
@@ -32,35 +44,19 @@ class TLDetector(object):
         simulator. When testing on the vehicle, the color state will not be available. You'll need to
         rely on the position of the light and the camera image to predict it.
         '''
-        sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
-        sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)
+        self.tss = ApproximateTimeSynchronizer([Subscriber("/vehicle/traffic_lights", TrafficLightArray),
+                                               Subscriber("/image_color", Image),
+                                               Subscriber("/current_pose", PoseStamped)], 30, 0.1)
+        self.tss.registerCallback(self.light_image_pose_cb)
 
-        config_string = rospy.get_param("/traffic_light_config")
-        self.config = yaml.load(config_string)
-
-        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
-
-        self.bridge = CvBridge()
-        self.light_classifier = TLClassifier()
-        self.listener = tf.TransformListener()
-
-        self.state = TrafficLight.UNKNOWN
-        self.last_state = TrafficLight.UNKNOWN
-        self.last_wp = -1
-        self.state_count = 0
+        
 
         rospy.spin()
-
-    def pose_cb(self, msg):
-        self.pose = msg
 
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
 
-    def traffic_cb(self, msg):
-        self.lights = msg.lights
-
-    def image_cb(self, msg):
+    def light_image_pose_cb(self, traffic_lights_msg, image_msg, pose_msg):
         """Identifies red lights in the incoming camera image and publishes the index
             of the waypoint closest to the red light's stop line to /traffic_waypoint
 
@@ -68,8 +64,10 @@ class TLDetector(object):
             msg (Image): image from car-mounted camera
 
         """
-        self.has_image = True
-        self.camera_image = msg
+        self.pose = pose_msg
+        self.lights = traffic_lights_msg.lights
+        self.camera_image = image_msg
+
         light_wp, state = self.process_traffic_lights()
 
         '''
@@ -113,10 +111,6 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        if(not self.has_image):
-            self.prev_light_loc = None
-            return False
-
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
         #Get classification


### PR DESCRIPTION
There were some issues with the bridge not publishing the correct timestamps. With those changes one can now introduce a TimeSynchronizerSubscriber, synchronizing the individual subscriptions in the tl_detector.

This fixes the issue that, at least in simulation, the traffic lights (resp. their states), pose and the camera image are heavily out of sync.