### PR TITLE
Update dbw_mkz_msgs

### DIFF
--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -99,7 +99,7 @@ class Bridge(object):
 
     def create_steer(self, val):
         st = SteeringReport()
-        st.steering_wheel_angle_cmd = val * math.pi/180.
+        st.steering_wheel_cmd = val * math.pi/180.
         st.enabled = True
         st.speed = self.vel
         return st


### PR DESCRIPTION
The package `dbw_mkz` was updated recently so the message  `SteeringReport` has no longer the field `steering_wheel_angle_cmd`. Instead, now it is called `steering_wheel_cmd`