### PR TITLE
fix issue with camera messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN apt-get install -y ros-$ROS_DISTRO-image-proc
 # socket io
 RUN apt-get install -y netbase
 
-RUN mkdir /capstone
-VOLUME ["/capstone"]
-VOLUME ["/root/.ros/log/"]
-WORKDIR /capstone/ros
+# fixes problem with recieving images from simulator 
+RUN pip install pillow --upgrade
+
+# RUN mkdir /capstone
+# VOLUME ["/capstone"]
+# VOLUME ["/root/.ros/log/"]
+# WORKDIR /capstone/ros

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+DOCKER_NAME=udi_docker
+srcdir ?= $(shell pwd)
+
+build:
+	docker build -f Dockerfile -t $(DOCKER_NAME) .
+
+run:
+	docker run -it -p 4567:4567 -v $(srcdir):/capstone $(DOCKER_NAME)
+

--- a/README.md
+++ b/README.md
@@ -34,15 +34,14 @@ Run the docker file
 make run
 ```
 
-This set-up port forwarding and mounts the current local directory as the ```capstone``` directory inside the docker container. Once inside the docker you can continue working as usual i.e. 
+This sets up port forwarding and mounts the current local directory as the ```capstone``` directory inside the docker container. Once inside the docker you can continue working as usual i.e. 
 
-```cd capstone/ros```.  
+```cd capstone/ros```    
 ```catkin_make``` 
 
 etc...
 
-
-To exit the docker container type 
+To exit type:
 
 ```exit```
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,28 @@ Please use **one** of the two installation options, either native **or** docker 
 [Install Docker](https://docs.docker.com/engine/installation/)
 
 Build the docker container
-```bash
-docker build . -t capstone
+
+```
+make build
 ```
 
 Run the docker file
-```bash
-docker run -p 4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it capstone
+
 ```
+make run
+```
+
+This set-up port forwarding and mounts the current local directory as the ```capstone``` directory inside the docker container. Once inside the docker you can continue working as usual i.e. 
+
+```cd capstone/ros```.  
+```catkin_make``` 
+
+etc...
+
+
+To exit the docker container type 
+
+```exit```
 
 ### Port Forwarding
 To set up port forwarding, please refer to the "uWebSocketIO Starter Guide" found in the classroom (see Extended Kalman Filter Project lesson).


### PR DESCRIPTION
1. Modified the Dockerfile
* Updates the pillow version. This crucially fixes an error with receiving camera images from the simulator. 
* No capstone directories are created here anymore, as we will mount these instead from the local file system (see makefile)

2. Added a Makefile to manage running and creating docker container
* Includes port forwarding
* Now mounts the local directory as the capstone directory. this makes development simpler.

running docker is now as simple as
`make build` and `make run`

followed by `cd capstone/ros` 

then the build and run process as usual (`caktin_make` & `source` etc)

