### PR TITLE
Update lowpass.py

### DIFF
--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -2,7 +2,7 @@
 class LowPassFilter(object):
     def __init__(self, tau, ts):
         self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+        self.b = 1- self.a
 
         self.last_val = 0.
         self.ready = False


### PR DESCRIPTION
It is a minor change but it is very clear now what this class is going to do. 

0<a<1 is a weight multiplied to current measurement and (1-a) multiplied to the last_value where last_value is the function of last_measurement. 

I would go ahead and remove b altogether and just use a and (1-a)