### PR TITLE
Upgrade pip prior to running pip install to fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get upgrade -y
 
 # install python packages
 RUN apt-get install -y python-pip
+RUN pip install --upgrade pip
 COPY requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Fixes the below error when running `docker build . -t capstone`:

```
#15 39.46 Collecting markdown>=2.6.8 (from tensorflow-tensorboard<0.2.0,>=0.1.0->tensorflow==1.3.0->-r requirements.txt (line 10))
#15 39.69   Downloading https://files.pythonhosted.org/packages/fd/d6/9eeda2f440ef798c8222b77d7355199345ce3477941d8a02a2024ccb9ed2/Markdown-3.3.3.tar.gz (319kB)
#15 40.01     Complete output from command python setup.py egg_info:
#15 40.02     Traceback (most recent call last):
#15 40.02       File "<string>", line 1, in <module>
#15 40.02       File "/tmp/pip-build-0sLo_B/markdown/setup.py", line 39, in <module>
#15 40.02         __version__, __version_info__ = get_version()
#15 40.02       File "/tmp/pip-build-0sLo_B/markdown/setup.py", line 32, in get_version
#15 40.02         import importlib.util
#15 40.02     ImportError: No module named util
#15 40.02     
#15 40.02     ----------------------------------------
#15 40.53 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-0sLo_B/markdown/
#15 41.23 You are using pip version 8.1.1, however version 20.2.4 is available.
#15 41.23 You should consider upgrading via the 'pip install --upgrade pip' command.
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c pip install -r requirements.txt]: runc did not terminate sucessfully
```